### PR TITLE
Fix back-end startup issue

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,7 @@
 import pika
 import time
 import os
-import psycopg2-binary
+import psycopg2
 
 # Sleep time for BE to connect
 sleepTime = 20


### PR DESCRIPTION
Looks like **Back End** is using psycopg2-binary in requirements.txt (which means it won't have to be recompiled each time you do a pip install) but the module should still just be imported as psycopg2 in your app.py file. Otherwise it will toss an error.